### PR TITLE
Add timezone function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,109 +2,134 @@
 
 Get a [valid HTML `datetime` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTimeElement/datetime) for the HTML `<time>` element:
 
-- `datetime` for a specific moment
-- `datetimeDuration` for a duration
-- **(not available yet)** `datetimeTz` for a timezone offset
+- [`datetime()`](#expressing-moments-with-datetime) for a specific moment;
+- [`datetimeDuration()`](#expressing-durations-with-datetimeduration) for a duration;
+- [`datetimeTz()`](#expressing-timezone-offsets-with-datetimetz) for a timezone offset.
 
-The whole package is [< 1 KB compressed](https://bundlephobia.com/result?p=datetime-attribute) and tree-shakeable.
+The whole package is [< 1 KB compressed](https://bundlephobia.com/result?p=datetime-attribute) and tree-shakeable.
 
 ## Installation
 
 `npm install datetime-attribute`
 
-In your script:
+Import the functions you need in your script:
 
 ```js
-import { datetime, datetimeDuration } from 'datetime-attribute'
+import { datetime, datetimeDuration, datetimeTz } from 'datetime-attribute'
 ```
 
-This package is provided for modern usage with standard JavaScript syntax: it
-is up to you to transpile it for legacy browsers. Also, you can’t import it
-using `require('datetime-attribute')`. If it’s something you’d like, feel free
-to open an issue and/or a PR that won’t have any side effects.
+Not a NPM users? Copy/paste [the code](https://raw.githubusercontent.com/meduzen/datetime-attribute/main/index.js) in your project.
 
-## Usage
+## Expressing moments with `datetime()`
 
-`datetime()` accepts two optional arguments: a [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date), and a _precision_ string ([view them all](#advanced-usage-for-datetime)).
+`datetime()` accepts two optional arguments: a [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date), and a [_precision_ string](#available-precision-strings).
 
 ```js
 const now = new Date() // We’re 14 March 2021 and it’s 10:29 in Brussels.
 
-datetime(now) // '2021-03-14'
-
+datetime(now)          // '2021-03-14'
 datetime(now, 'local') // '2021-03-14T10:29'
 ```
 
 Without argument, it defaults to _today_:
 ```js
-datetime() // today as YYYY-mm-dd
-
+datetime() // today formatted in YYYY-mm-dd
 datetime((new Date()), 'day') // same
 ```
 
-`datetimeDuration` requires an object with keys for different levels of durations, from seconds to weeks.
+### Available precision strings
+
+By default, `datetime()` precision is `day`, resulting in a `YYYY-mm-dd`
+output. A lot of other values are accepted, covering most of the spec.
+
+Date:
+
+|  precision | example output | description
+|--|--|--|
+| `day` | `2021-03-14` | the default, fitting a calendar |
+| `year` | `2021` | only the year |
+| `yearless` | `03-14` | a day in a month |
+| `month` | `2021-03` | a month in a year |
+| `week` | `2021W10` | the week number ([ISO-8601 spec](https://en.wikipedia.org/wiki/ISO_week_date)) and its year |
+
+Time:
+
+|  precision | example output | description
+|--|--|--|
+| `time` | `10:29` | hours and minutes, like most clock
+| `second` | `10:29:00` | same, with precision up to seconds
+| `ms` | `10:29:00.000` | same, with precision up to milliseconds
+
+Date + time:
+
+|  precision | example output | description
+|--|--|--|
+`local` | `2021-03-14T10:29` | a local datetime (= date + time)
+`local second` | `2021-03-14T10:29:00` | same, with precision up to seconds
+`local ms` | `2021-03-14T10:29:00.000` | same, with precision up to milliseconds
+`global ms` | `2021-03-14T09:29:00.000Z` | the same moment shifted to UTC time
+
+(Not supported yet: global time with seconds and minutes precision.)
+
+## Expressing durations with `datetimeDuration()`
+
+`datetimeDuration()` requires an object with entries for different levels of durations, from seconds to weeks.
 
 ```js
 const duration = {
-  w: 3, // 3 weeks
-  d: 5, // 5 days
-  h: 10, // 10 hours
-  m: 43, // 43 minutes
+  w: 3,   //     3 weeks
+  d: 5,   //     5 days
+  h: 10,  //    10 hours
+  m: 43,  //    43 minutes
   s: 2.61 // 2.610 seconds
 }
 
-const durationAttr = datetimeDuration(duration) // 'P3W5DT10H43M2'
+datetimeDuration(duration) // 'P3W5DT10H43M2'
 ```
 
 All object keys are optional:
 
 ```js
-const durationAttrWithHours = datetimeDuration({ h: 17 }) // 'PT17H'
+datetimeDuration({ h: 17 }) // 'PT17H'
 ```
 
 Values exceeding a unit are not thrown away:
 
 ```js
-const durationAttrWithHours = datetimeDuration({ h: 31, m: 63, s: 175 }) // 'P1DT8H5M55S'
+datetimeDuration({ h: 31, m: 63, s: 175 }) // 'P1DT8H5M55S'
 ```
 
+## Expressing timezone offsets with `datetimeTz()`
 
-## Advanced usage
+Timezone offsets are a comparison against [UTC time](https://en.wikipedia.org/wiki/Coordinated_Universal_Time). For example, `+01:00` means “one hour ahead of UTC time” and `-05:00` means “five hours behind UTC time”.
 
-By default, the `datetime` precision is `day`, resulting in a `YYYY-mm-dd`
-output. A lot of other values are accepted, covering almost the whole spec.
-
-Others will be added later. Feel free to open issues or pull requests!
+`datetimeTz()` accepts two optional arguments for hours and minutes. Without argument, the local timezone offset is returned (and may differ based on daylight saving time).
 
 ```js
-const now = new Date() // We’re 14 March 2021 and it’s 10:29 in Brussels.
+datetimeTz(3)      // '+03:00' (Moscow)
 
-const datetimeAttr = datetime(now) // '2021-03-14'
-const datetimeAttrWithTime = datetime(now, 'local') // '2021-03-14T10:29'
+datetimeTz(-9, 30) // '-09:30' (Marquesas Islands)
+datetimeTz(-9.5)   // '-09:30' (same with 1 parameter)
+
+datetimeTz(0)      //      'Z' (Ghana; 'Z' is equal to '+00:00')
+
+// when in Belgium
+datetimeTz()       // '+01:00'
+datetimeTz()       // '+02:00' (under daylight time saving)
 ```
 
-### Date precision
+Note: values outside the real-life range (`-12:00` to `+14:00`) are currently not adjusted to fit in it. This means `datetimeTz(26)` will output `+26:00` instead of `+02:00`.
 
-- `datetime(now, 'day')  // '2021-03-14'`: the default one, fitting a calendar
-- `datetime(now, 'year') // '2021'`: only the year
-- `datetime(now, 'yearless') // '03-14'`: a day in a month
-- `datetime(now, 'month') // '2021-03'`: a month in a year
-- `datetime(now, 'week') // '2021W10'`: the week number ([ISO-8601 spec](https://en.wikipedia.org/wiki/ISO_week_date)) and its year.
-
-## Time precision
-
-- `datetime(now, 'time') // '10:29'`: hours and minutes, like most clock
-- `datetime(now, 'second') // '10:29:00'`: same, with precision up to seconds
-- `datetime(now, 'ms') // '10:29:00.000'`: same, with precision up to milliseconds
-
-## Date + time precision
-
-- `datetime(now, 'local') // '2021-03-14T10:29'`: a local datetime (= date + time)
-- `datetime(now, 'local second') '2021-03-14T10:29:00' // `: same, with precision up to seconds
-- `datetime(now, 'local ms') // '2021-03-14T10:29:00.000'`: same, with precision up to milliseconds
-- `datetime(now, 'global ms') // 2021-03-14T09:29:00.000Z`: the same moment, but shifted to the UTC time.
-- (later: global time with less precision)
+Curious about timezones? Have a look at [the timezone map](https://fr.m.wikipedia.org/wiki/Fichier:World_Time_Zones_Map.png) and the [daylight time saving chaos](https://en.wikipedia.org/wiki/Daylight_saving_time_by_country).
 
 ## Changelog
 
 See [releases](https://github.com/meduzen/datetime-attribute/releases).
+
+## Browser and tooling support
+
+`datetime-attribute` is provided for [modern browsers usage](https://github.com/meduzen/datetime-attribute/blob/main/browserslist) with standard JavaScript syntax:
+- it is up to you to transpile it for legacy browsers;
+- you can’t import it using `require('datetime-attribute')`.
+
+If you’d like one of those features, feel free to open an issue and/or a PR that won’t have any side effects for modern usage.

--- a/README.md
+++ b/README.md
@@ -25,14 +25,21 @@ to open an issue and/or a PR that won’t have any side effects.
 
 ## Usage
 
-`datetime` accepts a [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date) as argument, and optionally a [`precision` string](#advanced-usage).
+`datetime()` accepts two optional arguments: a [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date), and a _precision_ string ([view them all](#advanced-usage-for-datetime)).
 
 ```js
 const now = new Date() // We’re 14 March 2021 and it’s 10:29 in Brussels.
 
-const datetimeAttr = datetime(now) // '2021-03-14'
+datetime(now) // '2021-03-14'
 
-const datetimeAttrWithTime = datetime(now, 'local') // '2021-03-14T10:29'
+datetime(now, 'local') // '2021-03-14T10:29'
+```
+
+Without argument, it defaults to _today_:
+```js
+datetime() // today as YYYY-mm-dd
+
+datetime((new Date()), 'day') // same
 ```
 
 `datetimeDuration` requires an object with keys for different levels of durations, from seconds to weeks.

--- a/index.js
+++ b/index.js
@@ -47,6 +47,41 @@ export function datetime(date, precision = 'day') {
 }
 
 /**
+ * Create `datetime="+04:00"` timezone attribute for `<time>`.
+ * https://html.spec.whatwg.org/multipage/text-level-semantics.html#attr-time-datetime
+ * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#concept-timezone
+ * https://developer.mozilla.org/en-US/docs/Web/API/HTMLTimeElement/datetime
+ */
+export function datetimeTz(hours = 0, minutes = 0) {
+
+  // No arguments received: the local timezone offset is returned.
+  if (!('0' in arguments)) {
+    return datetimeTz(0, (new Date()).getTimezoneOffset() * -1)
+  }
+
+  if (typeof hours != 'number' || typeof minutes != 'number') {
+    throw new TypeError('hours and (optional) minutes must be numbers.');
+  }
+
+  // Convert given offset in minutes by merging parameters.
+  minutes = hours * 60 + minutes
+
+  // Offset sign: `+` (UTC ≥ 0) or `-` (UTC < 0).
+  const sign = minutes > 0 ? '+' : '-'
+
+  // Get hours and minutes.
+  hours = Math.trunc(minutes / 60)
+  minutes = minutes % 60
+
+  if (hours == 0 && minutes == 0 ) { return 'Z' }
+
+  // Remove sign (handled separately) and ignore the decimal part.
+  [hours, minutes] = [hours, minutes].map(value => Math.trunc(Math.abs(value)))
+
+  return sign + p(hours) + ':' + p(minutes)
+}
+
+/**
  * Create `datetime="P3DT2H8M32.541S"` duration attribute for `<time>`.
  * https://html.spec.whatwg.org/multipage/text-level-semantics.html#attr-time-datetime
  * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#concept-duration

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
  *
  * See also: https://www.brucelawson.co.uk/2012/best-of-time/
  */
-export function datetime(date, precision = 'day') {
+export function datetime(date = (new Date()), precision = 'day') {
   if (!(date instanceof Date)) {
       throw new TypeError('Input date should be of type `Date`');
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,4 +1,4 @@
-import { datetime, datetimeDuration, daysBetween, weekNumber } from '..'
+import { datetime, datetimeDuration, datetimeTz, daysBetween, weekNumber } from '..'
 
 const togoIndependanceDay = new Date(1960, 3, 27)
 const date = togoIndependanceDay // alias for the sake of brevity
@@ -50,6 +50,25 @@ describe('datetimeDuration', () => {
   test('complete object with too high values', () => expect(datetimeDuration(durationWithTooHighValues)).toBe('P5W6DT12H55M55.3S'))
   test('hours only', () => expect(datetimeDuration(durationInHours)).toBe('PT17H'))
   test('days only', () => expect(datetimeDuration(durationInDays)).toBe('P6W1D'))
+})
+
+describe('datetimeTz', () => {
+  test('is a function', () => expect(datetimeTz).toBeInstanceOf(Function))
+  test('0', () => expect(datetimeTz(0)).toBe('Z'))
+  test('-3', () => expect(datetimeTz(-3)).toBe('-03:00'))
+  test('0, -30', () => expect(datetimeTz(0, -30)).toBe('-00:30'))
+  test('0, 30', () => expect(datetimeTz(0, 30)).toBe('+00:30'))
+  test('1', () => expect(datetimeTz(1)).toBe('+01:00'))
+  test('-4.5', () => expect(datetimeTz(-4.5)).toBe('-04:30'))
+  test('4, 30', () => expect(datetimeTz(4, 30)).toBe('+04:30'))
+  test('12, 45', () => expect(datetimeTz(12, 45)).toBe('+12:45'))
+  test('12.75', () => expect(datetimeTz(12.75)).toBe('+12:45'))
+  test('-8', () => expect(datetimeTz(-8)).toBe('-08:00'))
+  test('2, -200', () => expect(datetimeTz(2, -200)).toBe('-01:20'))
+  test('non number', () => expect(() => datetimeTz('Z')).toThrow(TypeError))
+
+  // This one can’t be tested providing an exact value as the output depends on client timezone and daylight time saving.
+  test('()', () => expect(datetimeTz()).toBe(datetimeTz(0, (new Date()).getTimezoneOffset() * -1)))
 })
 
 describe('weekNumber', () => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,7 +12,8 @@ const december31th2021                = new Date(2021, 11, 31, 10, 10, 12)
 
 describe('datetime', () => {
   test('is a function', () => expect(datetime).toBeInstanceOf(Function))
-  test('()', () => expect(() => datetime()).toThrow(TypeError))
+  test('wrong type', () => expect(() => datetime(123)).toThrow(TypeError))
+  test('()', () => expect(datetime()).toBe(datetime((new Date()))))
   test('no precision', () => expect(datetime(date)).toBe('1960-04-27'))
   test('day', () => expect(datetime(date, 'day')).toBe('1960-04-27'))
   test('year', () => expect(datetime(date, 'year')).toBe('1960'))


### PR DESCRIPTION
Closes #1.

Lleft as an improvement for later (and already started locally): normalizing timezone offsets to human ranges (e.g. a `+27:00` means `+03:00`).

Also:
- Breaking: `datetime()` without parameter is now accepted: instead of throwing an error it defaults to _now_.
- Rewrite the whole documentation.