### PR TITLE
Add missing `datetime()` precision keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Until it reaches 1.0.0, breaking changes will bump the _MINOR_ digit (the second one).
 
+## Unreleased (202x-xx-xx)
+
+Compare with [last version](https://github.com/meduzen/datetime-attribute/compare/0.2.1...main).
+
+### New
+
+- Add `datetime()` missing global precisions.
+
+### Changed
+
+- `datetime()`: `local` and `global` keywords are now `datetime` and `utc`.
+
 ## v0.2.1 (2021-04-02)
 
 Compare with [previous version](https://github.com/meduzen/datetime-attribute/compare/0.1.7...0.2.1).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Get a [valid HTML `datetime` attribute](https://developer.mozilla.org/en-US/docs
 - [`datetimeDuration()`](#expressing-durations-with-datetimeduration) for a duration;
 - [`datetimeTz()`](#expressing-timezone-offsets-with-datetimetz) for a timezone offset.
 
-The whole package is [~ 1 KB compressed](https://bundlephobia.com/result?p=datetime-attribute) and tree-shakeable. It aims to be [spec](https://html.spec.whatwg.org/multipage/text-level-semantics.html#attr-time-datetime) complete.
+The whole package is [~ 1 KB compressed](https://bundlephobia.com/result?p=datetime-attribute) and tree-shakeable. It aims to be [spec](https://html.spec.whatwg.org/multipage/text-level-semantics.html#attr-time-datetime) complete.
 
 ## Installation
 
@@ -22,7 +22,7 @@ Not a NPM users? Copy/paste [the code](https://raw.githubusercontent.com/meduzen
 
 ## Expressing moments with `datetime()`
 
-`datetime()` accepts two optional arguments: a [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date), and a [_precision_ string](#available-precision-strings).
+`datetime()` accepts two optional arguments: a [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date), and a [_precision_ keywords](#available-precision-keywords).
 
 ```js
 const now = new Date() // We’re 14 March 2021 and it’s 10:29 in Brussels.
@@ -37,12 +37,12 @@ datetime() // today formatted in YYYY-mm-dd
 datetime((new Date()), 'day') // same
 ```
 
-### Available precision strings
+### Available precision keywords
 
 By default, `datetime()` precision is `day`, resulting in a `YYYY-mm-dd`
 output. A lot of other values are accepted, covering most of the spec.
 
-Date:
+#### Date
 
 |  precision | example output | description
 |--|--|--|
@@ -52,27 +52,31 @@ Date:
 | `month` | `2021-03` | a month in a year |
 | `week` | `2021W10` | the week number ([ISO-8601 spec](https://en.wikipedia.org/wiki/ISO_week_date)) and its year |
 
-Time:
+#### Time and UTC time
 
 |  precision | example output | description
 |--|--|--|
 | `time` | `10:29` | hours and minutes, like most clock
-| `second` | `10:29:00` | same, with precision up to seconds
-| `ms` | `10:29:00.000` | same, with precision up to milliseconds
-| `time utc` | `09:29Z` | the same moment shifted to UTC time
-| `second utc` | `09:29:00Z` | the same moment shifted to UTC time with precision up to seconds
-| `ms utc` | `09:29:00.000Z` | the same moment shifted to UTC time with precision up to milliseconds
+| `time utc` | `09:29Z` | same as previous, shifted to UTC time
+| `second` | `10:29:00` | time with precision up to seconds
+| `second utc` | `09:29:00Z` | same as previous, shifted to UTC time
+| `ms` | `10:29:00.000` | time with precision up to milliseconds
+| `ms utc` | `09:29:00.000Z` | same as previous, shifted to UTC time
 
-Date + time:
+💡 Basically, you get UTC time by adding ` utc` behind a time keyword.
+
+#### Datetime and UTC datetime
 
 |  precision | example output | description
 |--|--|--|
-`local` | `2021-03-14T10:29` | a local datetime (= date + time)
-`local second` | `2021-03-14T10:29:00` | same, with precision up to seconds
-`local ms` | `2021-03-14T10:29:00.000` | same, with precision up to milliseconds
-`global` | `2021-03-14T09:29Z` | the same moment shifted to UTC time
-`global second` | `2021-03-14T09:29:00Z` | the same moment shifted to UTC time with precision up to seconds
-`global ms` | `2021-03-14T09:29:00.000Z` | the same moment shifted to UTC time with precision up to milliseconds
+`datetime` | `2021-03-14T10:29` | a local datetime (= date + time separated by `T`)
+`datetime utc` | `2021-03-14T09:29Z` | same as previous, shifted to UTC time
+`datetime second` | `2021-03-14T10:29:00` | time with precision up to seconds
+`datetime second utc` | `2021-03-14T09:29:00Z` | same as previous, shifted to UTC time
+`datetime ms` | `2021-03-14T10:29:00.000` | time with precision up to milliseconds
+`datetime ms utc` | `2021-03-14T09:29:00.000Z` | same as previous, shifted to UTC time
+
+💡 Basically, you get UTC datetime by adding ` utc` behind a datetime keyword.
 
 ## Expressing durations with `datetimeDuration()`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Get a [valid HTML `datetime` attribute](https://developer.mozilla.org/en-US/docs
 - [`datetimeDuration()`](#expressing-durations-with-datetimeduration) for a duration;
 - [`datetimeTz()`](#expressing-timezone-offsets-with-datetimetz) for a timezone offset.
 
-The whole package is [< 1 KB compressed](https://bundlephobia.com/result?p=datetime-attribute) and tree-shakeable.
+The whole package is [~ 1 KB compressed](https://bundlephobia.com/result?p=datetime-attribute) and tree-shakeable. It aims to be [spec](https://html.spec.whatwg.org/multipage/text-level-semantics.html#attr-time-datetime) complete.
 
 ## Installation
 
@@ -59,6 +59,9 @@ Time:
 | `time` | `10:29` | hours and minutes, like most clock
 | `second` | `10:29:00` | same, with precision up to seconds
 | `ms` | `10:29:00.000` | same, with precision up to milliseconds
+| `time utc` | `09:29Z` | the same moment shifted to UTC time
+| `second utc` | `09:29:00Z` | the same moment shifted to UTC time with precision up to seconds
+| `ms utc` | `09:29:00.000Z` | the same moment shifted to UTC time with precision up to milliseconds
 
 Date + time:
 
@@ -67,9 +70,9 @@ Date + time:
 `local` | `2021-03-14T10:29` | a local datetime (= date + time)
 `local second` | `2021-03-14T10:29:00` | same, with precision up to seconds
 `local ms` | `2021-03-14T10:29:00.000` | same, with precision up to milliseconds
-`global ms` | `2021-03-14T09:29:00.000Z` | the same moment shifted to UTC time
-
-(Not supported yet: global time with seconds and minutes precision.)
+`global` | `2021-03-14T09:29Z` | the same moment shifted to UTC time
+`global second` | `2021-03-14T09:29:00Z` | the same moment shifted to UTC time with precision up to seconds
+`global ms` | `2021-03-14T09:29:00.000Z` | the same moment shifted to UTC time with precision up to milliseconds
 
 ## Expressing durations with `datetimeDuration()`
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
  *
  * See also: https://www.brucelawson.co.uk/2012/best-of-time/
  */
-export function datetime(date = (new Date()), precision = 'day') {
+export function datetime(date = (new Date()), precision = 'day', offset = 'Z') {
   if (!(date instanceof Date)) {
       throw new TypeError('Input date should be of type `Date`');
   }
@@ -23,10 +23,9 @@ export function datetime(date = (new Date()), precision = 'day') {
 
   // Extract substring from local date.
   const local = (start, end) => localMs.substr(start, end)
+  const utcDatetime = (start, end) => date.toJSON().substr(start, end)
 
   const formats = {
-    'global ms': () => date.toJSON(),
-
     'year': () => local(0, 4),          // 1960
     'month': () => local(0, 7),         // 1960-04
     'day': () => local(0, 10),          // 1960-04-27
@@ -41,6 +40,14 @@ export function datetime(date = (new Date()), precision = 'day') {
     'local': () => local(0, 16),        // 1960-04-27T00:00
     'local second': () => local(0, 19), // 1960-04-27T00:00:00
     'local ms': () => local(0, 23),     // 1960-04-27T00:00:00.123
+
+    'global': () => utcDatetime(0, 16) + 'Z',        // 1960-04-26T23:00Z
+    'global second': () => utcDatetime(0, 19) + 'Z', // 1960-04-26T23:00:00Z
+    'global ms': () => date.toJSON(),                // 1960-04-26T23:00:00.000Z
+
+    'time utc': () => utcDatetime(11, 5) + 'Z',   // 23:00Z
+    'second utc': () => utcDatetime(11, 8) + 'Z', // 23:00:00Z
+    'ms utc': () => utcDatetime(11, 12) + 'Z',    // 23:00:00.000Z
   }
 
   return (formats[precision] || formats.day)()

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ export function datetime(date = (new Date()), precision = 'day', offset = 'Z') {
 
   // Extract substring from local date.
   const local = (start, end) => localMs.substr(start, end)
-  const utcDatetime = (start, end) => date.toJSON().substr(start, end)
+  const utc = (start, end) => date.toJSON().substr(start, end)
 
   const formats = {
     'year': () => local(0, 4),          // 1960
@@ -37,17 +37,17 @@ export function datetime(date = (new Date()), precision = 'day', offset = 'Z') {
     'second': () => local(11, 8),       // 00:00:00
     'ms': () => local(11, 12),          // 00:00:00.123
 
-    'local': () => local(0, 16),        // 1960-04-27T00:00
-    'local second': () => local(0, 19), // 1960-04-27T00:00:00
-    'local ms': () => local(0, 23),     // 1960-04-27T00:00:00.123
+    'datetime': () => local(0, 16),        // 1960-04-27T00:00
+    'datetime second': () => local(0, 19), // 1960-04-27T00:00:00
+    'datetime ms': () => local(0, 23),     // 1960-04-27T00:00:00.123
 
-    'global': () => utcDatetime(0, 16) + 'Z',        // 1960-04-26T23:00Z
-    'global second': () => utcDatetime(0, 19) + 'Z', // 1960-04-26T23:00:00Z
-    'global ms': () => date.toJSON(),                // 1960-04-26T23:00:00.000Z
+    'datetime utc': () => utc(0, 16) + 'Z',        // 1960-04-26T23:00Z
+    'datetime second utc': () => utc(0, 19) + 'Z', // 1960-04-26T23:00:00Z
+    'datetime ms utc': () => date.toJSON(),                // 1960-04-26T23:00:00.000Z
 
-    'time utc': () => utcDatetime(11, 5) + 'Z',   // 23:00Z
-    'second utc': () => utcDatetime(11, 8) + 'Z', // 23:00:00Z
-    'ms utc': () => utcDatetime(11, 12) + 'Z',    // 23:00:00.000Z
+    'time utc': () => utc(11, 5) + 'Z',   // 23:00Z
+    'second utc': () => utc(11, 8) + 'Z', // 23:00:00Z
+    'ms utc': () => utc(11, 12) + 'Z',    // 23:00:00.000Z
   }
 
   return (formats[precision] || formats.day)()

--- a/tests/index.js
+++ b/tests/index.js
@@ -33,7 +33,12 @@ describe('datetime', () => {
   test('week on 2021-12-31', () => expect(datetime(december31th2021, 'week')).toBe('2021-W52'))
 
   // This one can’t be tested providing an exact value as the output depends on client timezone.
+  test('global', () => expect(datetime(date, 'global')).toBe(date.toJSON().substr(0, 16) + 'Z'))
   test('global ms', () => expect(datetime(date, 'global ms')).toBe(date.toJSON()))
+  test('global second', () => expect(datetime(date, 'global second')).toBe(date.toJSON().substr(0, 19) + 'Z'))
+  test('time utc', () => expect(datetime(date, 'time utc')).toBe(date.toJSON().substr(11, 5) + 'Z'))
+  test('second utc', () => expect(datetime(date, 'second utc')).toBe(date.toJSON().substr(11, 8) + 'Z'))
+  test('ms utc', () => expect(datetime(date, 'ms utc')).toBe(date.toJSON().substr(11, 12) + 'Z'))
 
   test('non supported precision', () => expect(datetime(date, 'n00t')).toBe('1960-04-27'))
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -22,9 +22,9 @@ describe('datetime', () => {
   test('time', () => expect(datetime(date, 'time')).toBe('00:00'))
   test('second', () => expect(datetime(date, 'second')).toBe('00:00:00'))
   test('ms', () => expect(datetime(date, 'ms')).toBe('00:00:00.000'))
-  test('local', () => expect(datetime(date, 'local')).toBe('1960-04-27T00:00'))
-  test('local second', () => expect(datetime(date, 'local second')).toBe('1960-04-27T00:00:00'))
-  test('local ms', () => expect(datetime(date, 'local ms')).toBe('1960-04-27T00:00:00.000'))
+  test('datetime', () => expect(datetime(date, 'datetime')).toBe('1960-04-27T00:00'))
+  test('datetime second', () => expect(datetime(date, 'datetime second')).toBe('1960-04-27T00:00:00'))
+  test('datetime ms', () => expect(datetime(date, 'datetime ms')).toBe('1960-04-27T00:00:00.000'))
   test('week on 1960-04-27', () => expect(datetime(date, 'week')).toBe('1960-W17'))
   test('week on 2021-01-01', () => expect(datetime(january1st, 'week')).toBe('2021-W53'))
   test('week on 2021-01-11', () => expect(datetime(january11th, 'week')).toBe('2021-W02'))
@@ -32,13 +32,13 @@ describe('datetime', () => {
   test('week on 2020-12-31', () => expect(datetime(december31th2020, 'week')).toBe('2020-W53'))
   test('week on 2021-12-31', () => expect(datetime(december31th2021, 'week')).toBe('2021-W52'))
 
-  // This one can’t be tested providing an exact value as the output depends on client timezone.
-  test('global', () => expect(datetime(date, 'global')).toBe(date.toJSON().substr(0, 16) + 'Z'))
-  test('global ms', () => expect(datetime(date, 'global ms')).toBe(date.toJSON()))
-  test('global second', () => expect(datetime(date, 'global second')).toBe(date.toJSON().substr(0, 19) + 'Z'))
+  // These ones can’t be tested providing an exact value as the output depends on client timezone.
   test('time utc', () => expect(datetime(date, 'time utc')).toBe(date.toJSON().substr(11, 5) + 'Z'))
   test('second utc', () => expect(datetime(date, 'second utc')).toBe(date.toJSON().substr(11, 8) + 'Z'))
   test('ms utc', () => expect(datetime(date, 'ms utc')).toBe(date.toJSON().substr(11, 12) + 'Z'))
+  test('datetime utc', () => expect(datetime(date, 'datetime utc')).toBe(date.toJSON().substr(0, 16) + 'Z'))
+  test('datetime second utc', () => expect(datetime(date, 'datetime second utc')).toBe(date.toJSON().substr(0, 19) + 'Z'))
+  test('datetime ms utc', () => expect(datetime(date, 'datetime ms utc')).toBe(date.toJSON()))
 
   test('non supported precision', () => expect(datetime(date, 'n00t')).toBe('1960-04-27'))
 })


### PR DESCRIPTION
Closes #2.