### PR TITLE
Enforce timezone offsets boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ datetimeDuration({ m: 175 }, false) // 'PT175M'
 
 Timezone offsets are a comparison against [UTC time](https://en.wikipedia.org/wiki/Coordinated_Universal_Time). For example, `+01:00` means “one hour ahead of UTC time” and `-05:00` means “five hours behind UTC time”.
 
-`tzOffset()` accepts two optional arguments for hours and minutes. Without argument, the local timezone offset is returned (and may differ based on daylight saving time).
+`tzOffset()` accepts three optional arguments for hours, minutes, and [compliance to real-life boundaries](#real-life-timezone-offset). Without argument, the local timezone offset is returned (and may differ based on daylight saving time).
 
 ```js
 import { tzOffset } from 'datetime-attribute'
@@ -239,7 +239,16 @@ tzOffset()       // '+01:00'
 tzOffset()       // '+02:00' (under daylight time saving)
 ```
 
-Note: values outside the real-life range (`-12:00` to `+14:00`) are not adjusted to fit in it, but to fit into the spec range (`-23:59` to `+23:59`) . This means `tzOffset(26)` will output `+02:00` instead of `+26:00`.
+### Real-life timezone offset
+
+The timezone offset will be adjusted to fit in the spec range (from `-23:59` to `+23:59`). This means `tzOffset(44)` will output `+20:00` instead of `+44:00`.
+
+However, timezone offsets of countries in the world are all between `-12:00` and `+14:00`. If you want `tzOffset(44)` to output `-04:00` so that it matches real-life boundaries, pass it a third parameter (default: `false`):
+
+```js
+tzOffset(44) // '+20:00'
+tzOffset(44, 0, true) // '-04:00'
+```
 
 Curious about timezones? Have a look at [the timezone map](https://fr.m.wikipedia.org/wiki/Fichier:World_Time_Zones_Map.png) and the [daylight time saving chaos](https://en.wikipedia.org/wiki/Daylight_saving_time_by_country).
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ tzOffset()       // '+01:00'
 tzOffset()       // '+02:00' (under daylight time saving)
 ```
 
-Note: values outside the real-life range (`-12:00` to `+14:00`) are currently not adjusted to fit in it. This means `tzOffset(26)` will output `+26:00` instead of `+02:00`.
+Note: values outside the real-life range (`-12:00` to `+14:00`) are not adjusted to fit in it, but to fit into the spec range (`-23:59` to `+23:59`) . This means `tzOffset(26)` will output `+02:00` instead of `+26:00`.
 
 Curious about timezones? Have a look at [the timezone map](https://fr.m.wikipedia.org/wiki/Fichier:World_Time_Zones_Map.png) and the [daylight time saving chaos](https://en.wikipedia.org/wiki/Daylight_saving_time_by_country).
 

--- a/index.js
+++ b/index.js
@@ -56,12 +56,12 @@ export function datetime(date = (new Date()), precision = 'day') {
 /**
  * Create `datetime="2021-12-02T17:34-06:00"` attribute for `<time>`.
  */
- export function datetimeTz(date, precision = 'datetime', offsetHours = 0, offsetMinutes = 0) {
+ export function datetimeTz(date, precision = 'datetime', offsetHours = 0, offsetMinutes = 0, realLifeBoundaries = false) {
   let timezoneOffset = ''
 
   if (!precision.includes('utc')) { // ignore request for UTC conversion
     timezoneOffset = ('2' in arguments) // see similar line in tzOffset()
-      ? tzOffset(offsetHours, offsetMinutes)
+      ? tzOffset(offsetHours, offsetMinutes, realLifeBoundaries)
       : tzOffset()
   }
 
@@ -74,7 +74,7 @@ export function datetime(date = (new Date()), precision = 'day') {
  * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#concept-timezone
  * https://developer.mozilla.org/en-US/docs/Web/API/HTMLTimeElement/datetime
  */
-export function tzOffset(hours = 0, minutes = 0) {
+export function tzOffset(hours = 0, minutes = 0, realLifeBoundaries = false) {
 
   // No arguments received: the local timezone offset is returned.
   if (!('0' in arguments)) {
@@ -85,21 +85,45 @@ export function tzOffset(hours = 0, minutes = 0) {
     throw new TypeError('hours and (optional) minutes must be numbers.');
   }
 
-  // Convert given offset in minutes by merging parameters.
-  minutes = hours * 60 + minutes
+  // Convert given offset in minutes and ignore the decimal part.
+  minutes = Math.trunc(hours * 60 + minutes)
+
+  // Compute minutes to remove in order to suppress the excess of minutes.
+  const suppressMinutesExcess = limit => Math.floor(minutes / limit) * MINUTES_PER_DAY
+
+  if (realLifeBoundaries) {
+
+    /**
+     * Because lower and upper boundaries are not necessarily symetric,
+     * suppressing the minutes excess can lead to another excess, but
+     * on the other side (e.g. going from beyond +14 to below -12).
+     */
+
+    // Upper boundary
+    if(minutes > REAL_LIFE_UPPER_TIMEZONE) {
+      minutes -= suppressMinutesExcess(REAL_LIFE_UPPER_TIMEZONE)
+      return tzOffset(0, minutes, true)
+    }
+
+    // Lower boundary
+    if(minutes < REAL_LIFE_LOWER_TIMEZONE) {
+      minutes += suppressMinutesExcess(REAL_LIFE_LOWER_TIMEZONE)
+      return tzOffset(0, minutes, true)
+    }
+  }
 
   // Offset sign: `+` (UTC ≥ 0) or `-` (UTC < 0).
   const sign = minutes > 0 ? '+' : '-'
 
-  // Remove sign (handled separately) and ignore the decimal part.
-  minutes = Math.trunc(Math.abs(minutes))
+  // Remove sign (stored separately, see previous line).
+  minutes = Math.abs(minutes)
 
   /**
    * The timezone offset must stay between -23:59 and +23:59:
    * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#concept-timezone
    */
   if (minutes >= MINUTES_PER_DAY) {
-    minutes -= Math.floor(minutes / (MINUTES_PER_DAY)) * (MINUTES_PER_DAY)
+    minutes -= suppressMinutesExcess(MINUTES_PER_DAY)
   }
 
   // Get hours and minutes.
@@ -234,6 +258,8 @@ export function weekNumber(date) {
 
 const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24
 const MINUTES_PER_DAY = 60 * 24
+const REAL_LIFE_LOWER_TIMEZONE = -12 * 60
+const REAL_LIFE_UPPER_TIMEZONE = 14 * 60
 
 // Round a number to the provided precision.
 const round = (number, precision = 0) => {

--- a/index.js
+++ b/index.js
@@ -91,14 +91,22 @@ export function tzOffset(hours = 0, minutes = 0) {
   // Offset sign: `+` (UTC ≥ 0) or `-` (UTC < 0).
   const sign = minutes > 0 ? '+' : '-'
 
+  // Remove sign (handled separately) and ignore the decimal part.
+  minutes = Math.trunc(Math.abs(minutes))
+
+  /**
+   * The timezone offset must stay between -23:59 and +23:59:
+   * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#concept-timezone
+   */
+  if (minutes >= MINUTES_PER_DAY) {
+    minutes -= Math.floor(minutes / (MINUTES_PER_DAY)) * (MINUTES_PER_DAY)
+  }
+
   // Get hours and minutes.
   hours = Math.trunc(minutes / 60)
   minutes = minutes % 60
 
   if (hours == 0 && minutes == 0 ) { return 'Z' }
-
-  // Remove sign (handled separately) and ignore the decimal part.
-  [hours, minutes] = [hours, minutes].map(value => Math.trunc(Math.abs(value)))
 
   return sign + p(hours) + ':' + p(minutes)
 }
@@ -225,6 +233,7 @@ export function weekNumber(date) {
 \* --------------------- */
 
 const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24
+const MINUTES_PER_DAY = 60 * 24
 
 // Round a number to the provided precision.
 const round = (number, precision = 0) => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -79,6 +79,8 @@ describe('tzOffset', () => {
   test('12.75', () => expect(tzOffset(12.75)).toBe('+12:45'))
   test('-8', () => expect(tzOffset(-8)).toBe('-08:00'))
   test('2, -200', () => expect(tzOffset(2, -200)).toBe('-01:20'))
+  test('-35', () => expect(tzOffset(-35)).toBe('-11:00'))
+  test('62.75', () => expect(tzOffset(62.75)).toBe('+14:45'))
   test('non number', () => expect(() => tzOffset('Z')).toThrow(TypeError))
 
   // This one can’t be tested providing an exact value as the output depends on client timezone and daylight time saving.

--- a/tests/index.js
+++ b/tests/index.js
@@ -81,6 +81,11 @@ describe('tzOffset', () => {
   test('2, -200', () => expect(tzOffset(2, -200)).toBe('-01:20'))
   test('-35', () => expect(tzOffset(-35)).toBe('-11:00'))
   test('62.75', () => expect(tzOffset(62.75)).toBe('+14:45'))
+  test('-12, 0, true', () => expect(tzOffset(-12, 0, true)).toBe('-12:00'))
+  test('-12, -20, true', () => expect(tzOffset(-12, -20, true)).toBe('+11:40'))
+  test('-13, -20, true', () => expect(tzOffset(-13, -20, true)).toBe('+10:40'))
+  test('14, 45, true', () => expect(tzOffset(14, 45, true)).toBe('-09:15'))
+  test('62.75, 0, true', () => expect(tzOffset(62.75, 0, true)).toBe('-09:15'))
   test('non number', () => expect(() => tzOffset('Z')).toThrow(TypeError))
 
   // This one can’t be tested providing an exact value as the output depends on client timezone and daylight time saving.
@@ -98,6 +103,7 @@ describe('datetimeTz', () => {
   test('second -3', () => expect(datetimeTz(date, 'second', -3)).toBe('00:00:00-03:00'))
   test('ms +3.5', () => expect(datetimeTz(date, 'ms', 3.5)).toBe('00:00:00.000+03:30'))
   test('datetime +12:45', () => expect(datetimeTz(date, 'datetime', 12, 45)).toBe('1960-04-27T00:00+12:45'))
+  test('datetime +17, 30, true', () => expect(datetimeTz(date, 'datetime', 17, 30, true)).toBe('1960-04-27T00:00-06:30'))
   test('datetime second -6', () => expect(datetimeTz(date, 'datetime second', -6)).toBe('1960-04-27T00:00:00-06:00'))
   test('datetime ms +1', () => expect(datetimeTz(date, 'datetime ms', 1)).toBe('1960-04-27T00:00:00.000+01:00'))
 


### PR DESCRIPTION
Drafting this pull request to closes #10.


Right now it enforces the timezone offsets boundaries to stay between `-23:59` and `+23:59`. I still have to add a parameter to enforce in current real-life boundaries (see #10).