### PR TITLE
Fix zero-seconds duration returning `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Until it reaches 1.0.0, breaking changes will bump the _MINOR_ digit (the second
 
 Compare with [last version](https://github.com/meduzen/datetime-attribute/compare/0.6.0...main).
 
+### Changed
+
+- Forbid `null` as valid `duration()` parameter: (`duration(null)`) is now invalid, but `duration()` remains valid.
+
+### Fixed
+
+- Fix zero-seconds duration returning `null` instead of `PT0S`.
+
 ## v0.6.0 (2021-07-10)
 
 Compare with [previous version](https://github.com/meduzen/datetime-attribute/compare/0.5.1...0.6.0).

--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ export function tzOffset(hours = 0, minutes = 0, inRealLifeBoundaries = false) {
  *
  * See also: https://www.brucelawson.co.uk/2012/best-of-time/
  */
-export function duration(duration, convertExcess = true) {
+export function duration(duration = {}, convertExcess = true) {
 
   // Set default values for missing keys.
   let { w = 0, d = 0, h = 0, m = 0, s = 0 } = duration

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ export function duration(duration, convertExcess = true) {
 
   // At least one duration must be different than zero.
   if (![w, d, h, m, s].some(value => value)) {
-    return null
+    return 'PT0S'
   }
 
   // Convert units in excess (e.g. `{ m: 65 }` becomes `{ h: 1, m: 5 }`).

--- a/tests/index.js
+++ b/tests/index.js
@@ -71,7 +71,8 @@ describe('duration', () => {
 
   test('is a function', () => expect(duration).toBeInstanceOf(Function))
   test('()', () => expect(() => duration()).toThrow())
-  test('empty object {}', () => expect(duration({})).toBeNull())
+  test('empty object {}', () => expect(duration({})).toBe('PT0S'))
+  test('empty object {}', () => expect(duration({}, false)).toBe('PT0S'))
 
   test('complete object', () => expect(duration(durationObject)).toBe('P3W5DT10H43M2.61S'))
   test('complete object with too high values', () => expect(duration(durationWithTooHighValues)).toBe('P5W6DT12H55M55.3S'))

--- a/tests/index.js
+++ b/tests/index.js
@@ -70,7 +70,8 @@ describe('duration', () => {
   const durationInDays = { d: 43 }
 
   test('is a function', () => expect(duration).toBeInstanceOf(Function))
-  test('()', () => expect(() => duration()).toThrow())
+  test('()', () => expect(() => duration(null)).toThrow())
+  test('()', () => expect(duration()).toBe('PT0S'))
   test('empty object {}', () => expect(duration({})).toBe('PT0S'))
   test('empty object {}', () => expect(duration({}, false)).toBe('PT0S'))
 


### PR DESCRIPTION
Closes #19.