### PR TITLE
Fix broken `.getWeek()`

### DIFF
--- a/src/datetime-class.js
+++ b/src/datetime-class.js
@@ -2,8 +2,6 @@ import { MILLISECONDS_PER_WEEK } from './utils/const.js'
 import { datetime, weekNumber } from './index.js'
 
 export class DateTime extends Date {
-  // // Properties used as cache to avoid useless computations.
-  // _weekNumber
 
   /**
    * Returns the week of the year (`1`–`53`) of the specified date according to
@@ -16,11 +14,7 @@ export class DateTime extends Date {
    * @returns {number}
    */
   getWeek() {
-    if (!this._weekNumber) {
-      this._weekNumber = weekNumber(this)
-    }
-
-    return this._weekNumber
+    return weekNumber(this)
   }
 
   /**
@@ -31,7 +25,6 @@ export class DateTime extends Date {
    */
   setWeek(weekNumber) {
     const weeksDiffInMs = (weekNumber - this.getWeek()) * MILLISECONDS_PER_WEEK
-    this._weekNumber = weekNumber // update cached property
     return this.setTime(this.getTime() + weeksDiffInMs)
   }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -169,4 +169,8 @@ describe('DateTime class', () => {
   test('.getWeek', () => expect(summer.getWeek()).toBe(25))
   test('.setWeek', () => expect(summer.setWeek(26)).toBe(oneWeekAfterSummer.getTime()))
   test(".to('day')", () => expect(summer.to('day')).toBe('2021-06-28'))
+  test('weeks is changed when day changes', () => {
+    summer.setDate(summer.getDate() + 14)
+    return expect(summer.getWeek()).toBe(28)
+  })
 })


### PR DESCRIPTION
This PR:
- reverts d9707f000ff5a44196986cc9055fab838cbe1c21, which a bad idea because time manipulation comes from a lot of `Date` methods.
- adds related test.