### PR TITLE
Add alternative datetime separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Compare with [last published version](https://github.com/meduzen/datetime-attrib
 
 - Support years with more then 4 digits (`12345-01-01`).
 - Support years prior to year 1 (`-0051-01-01`).
+- Add [`setTimeSeparator()`](https://github.com/meduzen/datetime-attribute#datetime-separator) to customize the separator between date and time.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The package is lightweight ([~ 1.28 KB compressed](https://bundlejs.com/?q=datet
     - [time and UTC time](#time-and-utc-time)
     - [datetime and UTC datetime](#datetime-and-utc-datetime)
     - alternative to the UTC syntax with [`utc()`](#the-utc-shortcut)
+    - [datetime separator](#datetime-separator)
   - [**`tzOffset()`**](#expressing-timezone-offsets-with-tzoffset) to express a **timezone offset**
     - [hours-minutes separator](#hours-minutes-separator)
     - [real-life timezone offset](#real-life-timezone-offset)
@@ -174,6 +175,26 @@ utc(now)             // `2021-03-14T09:29Z`
 utc(now, 'datetime') // `2021-03-14T09:29Z`
 datetime(now, 'datetime utc') // `2021-03-14T09:29Z`
 ```
+
+### Datetime separator
+
+[Per spec](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#local-dates-and-times), the separator between date and time can be `T` (default) or ` ` (1 space).
+
+To change the separator, use `setTimeSeparator`:
+
+```js
+import { setTimeSeparator } from 'datetime-attribute'
+
+setTimeSeparator(' ')
+
+// All next datetime functions will follow the new setting.
+datetime(now) // `2021-03-14 10:29`
+
+// Switch back to the default.
+setTimeSeparator('T') // or `setTimeSeparator()`
+```
+
+Setting the separator to a space can be useful to deal with [MySQL](https://dev.mysql.com/doc/refman/8.0/en/datetime.html) or [MariaDB `DATETIME`](https://mariadb.com/kb/en/datetime/) column.
 
 ## Expressing timezone offsets with `tzOffset()`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datetime-attribute",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datetime-attribute",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "WTFPL",
       "devDependencies": {
         "@babel/core": "^7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datetime-attribute",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Generate datetime attributes for the <time> HTML element, following WHATWG and ISO8601 specs.",
   "type": "module",
   "sideEffects": false,

--- a/src/config/datetime.js
+++ b/src/config/datetime.js
@@ -1,0 +1,38 @@
+/**
+ * @typedef {Object} DateTimeOptions
+ * @property {('T'|' ')=} separator
+ */
+
+/**
+ * @type DateTimeOptions
+ */
+export const config = {
+  separator: 'T',
+}
+
+/**
+ * Set datetime related configuration
+ *
+ * @param {DateTimeOptions} options
+ * @returns {DateTimeOptions}
+ */
+export const setConfig = options => {
+
+  /**
+   * The separator can only be 'T' or ' '.
+   * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#local-dates-and-times
+   */
+  if (options.separator != 'T' && options.separator != ' ') {
+    throw new Error(`Invalid timezone separator. Use 'T' or ' '.`)
+  }
+
+  return Object.assign(config, options)
+}
+
+/**
+ * Set separator between date and time
+ *
+ * @param {('T'|' ')=} separator
+ * @returns {DateTimeOptions}
+ */
+export const setTimeSeparator = (separator = 'T') => setConfig({ separator })

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,2 @@
+export { setTimeSeparator } from './datetime.js'
+export { setTzSeparator } from './tz.js'

--- a/src/config/tz.js
+++ b/src/config/tz.js
@@ -6,7 +6,7 @@
 /**
  * @type TimezoneOptions
  */
-export let tzConfig = {
+export const tzConfig = {
   separator: ':',
 }
 
@@ -23,7 +23,7 @@ export const setTzConfig = options => {
    * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#time-zones
    */
   if (options.separator != ':' && options.separator != '') {
-    throw new Error(`Invalid timezone separator. Use ':'' or ''.`)
+    throw new Error(`Invalid timezone separator. Use ':' or ''.`)
   }
 
   return Object.assign(tzConfig, options)

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1,6 +1,7 @@
 import { weekNumber } from './utils/date.js'
 import { p } from './utils/string.js'
 import { tzOffset } from './timezone.js'
+import { config } from './config/datetime'
 
 /**
  * Create `datetime="2021-12-02"` attribute for `<time>`.
@@ -50,7 +51,11 @@ export function datetime(date = (new Date()), precision = 'day') {
 
   const addSignAndYearDigits = shouldAdd => shouldAdd ? sign + bigYearDigits : ''
 
-  // Extract substring from local date, prepend sign and missing years digits.
+  /**
+   * Extract substring from local date. When `start` is 0, the year is wanted:
+   * its sign and missing digits (for years with 5+ digits) are prepended.
+   */
+
   const local = (start, length) => addSignAndYearDigits(!start) + localMs.substr(start, length)
   const utc = (start, length) => addSignAndYearDigits(!start) + date.toJSON().substr(start, length) + 'Z'
 
@@ -79,7 +84,7 @@ export function datetime(date = (new Date()), precision = 'day') {
     'ms utc': () => utc(11, 12),    // 23:00:00.000Z
   }
 
-  return (formats[precision] || formats.day)()
+  return (formats[precision] || formats.day)().replace('T', config.separator)
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ export { datetime, utc, datetimeTz } from './datetime.js'
 export { duration } from './duration.js'
 export { tzOffset } from './timezone.js'
 
-export { setTzSeparator } from './utils/config.js'
+export { setTimeSeparator, setTzSeparator } from './config/index.js'
 export { daysBetween, weekNumber } from './utils/date.js'
 
 export { DateTime } from './datetime-class.js'

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -6,7 +6,7 @@ import {
 } from './utils/const.js'
 
 import { p } from './utils/string.js'
-import { tzConfig } from './utils/config.js'
+import { tzConfig } from './config/tz.js'
 
 /**
  * Create `datetime="+04:00"` timezone attribute for `<time>`.

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,15 +7,17 @@ import {
   tzOffset,
   daysBetween,
   weekNumber,
+  setTimeSeparator,
   setTzSeparator,
 } from '../src'
 
 /**
- * This one is currently not exported in the mail bundle (though it’s used by
- * `setTzSeparator`). It will appear in the main bundle when a new setting
- * will be added to the timezone configuration object.
+ * These config methods are currently not exported in the main bundle (though
+ * they are used by `setXxSeparator` functions). There’s no reason to move
+ * them to the main without any new entry in the configuration objects.
  */
-import { setTzConfig } from '../src/utils/config.js'
+import { setConfig } from '../src/config/datetime.js'
+import { setTzConfig } from '../src/config/tz.js'
 
 const togoIndependanceDay = new Date(1960, 3, 27)
 const date = togoIndependanceDay // alias for the sake of brevity
@@ -254,4 +256,43 @@ describe('DateTime class', () => {
     summer.setDate(summer.getDate() + 14)
     return expect(summer.getWeek()).toBe(28)
   })
+})
+
+// These tests are at the end as they change the widely-used separator config.
+
+describe('setTimeSeparator', () => {
+  test('is a function', () => expect(setTimeSeparator).toBeInstanceOf(Function))
+
+  test('no time separator', () => {
+    setTimeSeparator()
+    expect(datetime(date, 'datetime')).toBe('1960-04-27T00:00')
+  })
+
+  test('T as time separator', () => {
+    setTimeSeparator('T')
+    expect(datetime(date, 'datetime')).toBe('1960-04-27T00:00')
+  })
+
+  test('space as time separator', () => {
+    setTimeSeparator(' ')
+    expect(datetime(date, 'datetime')).toBe('1960-04-27 00:00')
+  })
+
+  test('invalid separator', () => expect(() => setTimeSeparator(42)).toThrow(Error))
+})
+
+describe('setConfig', () => {
+  test('is a function', () => expect(setConfig).toBeInstanceOf(Function))
+
+  test('T as time separator using setConfig', () => {
+    setConfig({ separator: 'T' })
+    expect(datetime(date, 'datetime')).toBe('1960-04-27T00:00')
+  })
+
+  test('space as time separator using setConfig', () => {
+    setConfig({ separator: ' ' })
+    expect(datetime(date, 'datetime')).toBe('1960-04-27 00:00')
+  })
+
+  test('invalid separator using setConfig', () => expect(() => setConfig({ separator: 42 })).toThrow(Error))
 })

--- a/types/config/datetime.d.ts
+++ b/types/config/datetime.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @typedef {Object} DateTimeOptions
+ * @property {('T'|' ')=} separator
+ */
+/**
+ * @type DateTimeOptions
+ */
+export const config: DateTimeOptions;
+export function setConfig(options: DateTimeOptions): DateTimeOptions;
+export function setTimeSeparator(separator?: ('T' | ' ') | undefined): DateTimeOptions;
+export type DateTimeOptions = {
+    separator?: ('T' | ' ') | undefined;
+};

--- a/types/config/index.d.ts
+++ b/types/config/index.d.ts
@@ -1,0 +1,2 @@
+export { setTimeSeparator } from "./datetime.js";
+export { setTzSeparator } from "./tz.js";

--- a/types/config/tz.d.ts
+++ b/types/config/tz.d.ts
@@ -5,7 +5,7 @@
 /**
  * @type TimezoneOptions
  */
-export let tzConfig: TimezoneOptions;
+export const tzConfig: TimezoneOptions;
 export function setTzConfig(options: TimezoneOptions): TimezoneOptions;
 export function setTzSeparator(separator?: (':' | '') | undefined): TimezoneOptions;
 export type TimezoneOptions = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 export { duration } from "./duration.js";
 export { tzOffset } from "./timezone.js";
-export { setTzSeparator } from "./utils/config.js";
 export { DateTime } from "./datetime-class.js";
 export { datetime, utc, datetimeTz } from "./datetime.js";
+export { setTimeSeparator, setTzSeparator } from "./config/index.js";
 export { daysBetween, weekNumber } from "./utils/date.js";

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectError, expectType } from 'tsd'
 import { DurationObject } from './duration'
-import { TimezoneOptions } from './utils/config'
+import { TimezoneOptions, setTzConfig } from './config/tz'
+import { DateTimeOptions, setConfig } from './config/datetime'
 import {
   DateTime,
   datetime,
@@ -10,10 +11,9 @@ import {
   tzOffset,
   daysBetween,
   weekNumber,
+  setTimeSeparator,
   setTzSeparator,
 } from '.'
-
-import { setTzConfig } from './utils/config'
 
 const togoIndependanceDay = new Date(1960, 3, 27)
 const date = togoIndependanceDay // alias for the sake of brevity
@@ -32,6 +32,17 @@ expectType<string>(utc())
 expectType<string>(utc(date))
 expectType<string>(utc(date, 'time'))
 expectError(utc(date, 'unsupported precision'))
+
+// setTimeSeparator and setConfig
+
+expectType<DateTimeOptions>(setTimeSeparator('T'))
+expectType<DateTimeOptions>(setTimeSeparator(' '))
+expectType<DateTimeOptions>(setTimeSeparator())
+expectError(() => setTimeSeparator(123))
+
+expectType<DateTimeOptions>(setConfig({ separator: 'T' }))
+expectType<DateTimeOptions>(setConfig({ separator: ' ' }))
+expectError(() => setConfig({ separator: 123 }))
 
 // duration
 


### PR DESCRIPTION
[Per spec](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#local-dates-and-times), the separator between date and time can be `T` (default) or ` ` (1 space):

`2021-03-14T10:29` and `2021-03-14 10:29` are both valid.

This PR adds this feature.