### PR TITLE
Remove confusing comment about SemVer for 0.x versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) starting 1.0.
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 


### PR DESCRIPTION
When I wrote the changelog back in the days, I had no idea the note about [0.x stability in `datetime-attribute`](https://github.com/meduzen/datetime-attribute/blob/50c24c30b0f363c6745ae986c2b23a4b1fde164f/CHANGELOG.md?plain=1#L3) was actually SemVer-compliant.

From ([SemVer spec, § 4](https://semver.org/#spec-item-4)):

> Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.

As it’s in the spec, it can be removed from this package changelog. 🥳