### PR TITLE
Attempt to fix CI error on `pnpm install`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,6 +25,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Use pnpm
       uses: pnpm/action-setup@v2
-    - run: pnpm install
+    - run: pnpm install --no-frozen-lockfile
     - run: pnpm test
     - run: pnpm run test-types


### PR DESCRIPTION
The error message is:

```
Lockfile is up to date, resolution step is skipped
 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with package.json

Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
Error: Process completed with exit code 1.
```

It happens because dependabot doesn’t support `pnpm`, so it doesn’t update the lock file when suggesting a dependency bump, which results in the lock file being outdated when the CI is triggered.

Situations where this shouldn’t have happened:
- dependabot starting to support `pnpm`;
- starting to use something else than dependabot (like the renovate bot, for example).