### PR TITLE
Add types to size-limit

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -52,5 +52,9 @@
     {
       "name": "**All modules** (`import *`)",
       "path": "src/index.js"
+    },
+    {
+      "name": "Types",
+      "path": ["types/*.d.ts", "!types/index.d.ts"]
     }
   ]


### PR DESCRIPTION
For awareness.

Can’t be done like the following 👇 because `index.d.ts` tries to import files that are in another folder.

```json
    {
      "name": "Types",
      "path": "index.d.ts"
    }
```