### PR TITLE
Revert "Add types to size-limit"

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -52,9 +52,5 @@
     {
       "name": "**All modules** (`import *`)",
       "path": "src/index.js"
-    },
-    {
-      "name": "Types",
-      "path": ["types/*.d.ts", "!types/index.d.ts"]
     }
   ]


### PR DESCRIPTION
Reverts meduzen/datetime-attribute#122 because it is actually trying to get executable JavaScript due to the config preset used is `@size-limit/preset-small-lib`. It seems not possible to have multiple configs, so the only two options would be to use:
1. `@size-limit/file`, which would not deal with JS modular imports and thus not expose sizes with tree shaking.
2. `@size-limit/preset-app` which would require a build process and bloat the local and CI installation size of the library.

These are not an acceptable trade-off for the only benefit of having `.d.ts` file size.

Gonna open an issue in [ai/size-limit](https://github.com/ai/size-limit) to see how to deal with this use case.