### PR TITLE
Add ESLint Vitest plugin (`eslint-vitest-plugin`)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,9 @@
 import tseslint from 'typescript-eslint'
 import js from '@eslint/js'
+import vitest from 'eslint-plugin-vitest'
 
 export default tseslint.config(
   js.configs.recommended,
-
   {
     files: ['**/*.js'],
     languageOptions: {
@@ -62,6 +62,18 @@ export default tseslint.config(
       }],
       'template-curly-spacing': [2, 'never'],
       'template-tag-spacing': [2, 'always'],
+    },
+  },
+  {
+    files: ['**/*.test.js'],
+    plugins: { vitest },
+    rules: {
+      ...vitest.configs.recommended.rules,
+    },
+    languageOptions: {
+      globals: {
+        ...vitest.environments.env.globals,
+      },
     },
   },
 )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,7 +69,10 @@ export default tseslint.config(
     plugins: { vitest },
     rules: {
       ...vitest.configs.recommended.rules,
+      // ...vitest.configs.all.rules, // worth testing from time to time…
+      // 'vitest/consistent-test-it': 0,
       'vitest/no-test-return-statement': 1,
+      // 'vitest/prefer-expect-assertions': 0, // when testing `vitest.configs.all.rules`
       'vitest/require-to-throw-message': 1,
     },
     languageOptions: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,7 @@ export default tseslint.config(
     rules: {
       ...vitest.configs.recommended.rules,
       'vitest/no-test-return-statement': 1,
+      'vitest/require-to-throw-message': 1,
     },
     languageOptions: {
       globals: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,6 +69,7 @@ export default tseslint.config(
     plugins: { vitest },
     rules: {
       ...vitest.configs.recommended.rules,
+      'vitest/no-test-return-statement': 1,
     },
     languageOptions: {
       globals: {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@vitest/coverage-v8": "^1.4.0",
     "@vitest/ui": "^1.4.0",
     "eslint": "^9.0.0",
+    "eslint-plugin-vitest": "0.4.2-beta.3",
     "size-limit": "^11.1.2",
     "tsd": "^0.31.0",
     "typescript": "^5.4.4",

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "@vitest/coverage-v8": "^1.4.0",
     "@vitest/ui": "^1.4.0",
     "eslint": "^9.0.0",
-    "eslint-plugin-vitest": "0.4.2-beta.3",
+    "eslint-plugin-vitest": "0.4.2-beta.5",
     "size-limit": "^11.1.2",
     "tsd": "^0.31.0",
     "typescript": "^5.4.4",
-    "typescript-eslint": "^7.5.0",
+    "typescript-eslint": "^7.6.0",
     "vitest": "^1.4.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ devDependencies:
   eslint:
     specifier: ^9.0.0
     version: 9.0.0
+  eslint-plugin-vitest:
+    specifier: 0.4.2-beta.3
+    version: 0.4.2-beta.3(eslint@9.0.0)(typescript@5.4.4)(vitest@1.4.0)
   size-limit:
     specifier: ^11.1.2
     version: 11.1.2
@@ -1188,6 +1191,27 @@ packages:
       plur: 4.0.0
       string-width: 4.2.3
       supports-hyperlinks: 2.3.0
+    dev: true
+
+  /eslint-plugin-vitest@0.4.2-beta.3(eslint@9.0.0)(typescript@5.4.4)(vitest@1.4.0):
+    resolution: {integrity: sha512-3SrcEvVKEA0k8HkOpWkdU6zMlbt2fPG14LATAYvdvF9v5cuQ2Q2wWi7VcTcpV5QXMQYIyKmfBd2+lYu+OmEr2w==}
+    engines: {node: ^18.0.0 || >= 20.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '*'
+      eslint: ^8.57.0 || ^9.0.0
+      vitest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      vitest:
+        optional: true
+    dependencies:
+      '@typescript-eslint/utils': 7.5.0(eslint@9.0.0)(typescript@5.4.4)
+      eslint: 9.0.0
+      vitest: 1.4.0(@vitest/ui@1.4.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: true
 
   /eslint-rule-docs@1.1.235:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ devDependencies:
     specifier: ^9.0.0
     version: 9.0.0
   eslint-plugin-vitest:
-    specifier: 0.4.2-beta.3
-    version: 0.4.2-beta.3(eslint@9.0.0)(typescript@5.4.4)(vitest@1.4.0)
+    specifier: 0.4.2-beta.5
+    version: 0.4.2-beta.5(eslint@9.0.0)(typescript@5.4.4)(vitest@1.4.0)
   size-limit:
     specifier: ^11.1.2
     version: 11.1.2
@@ -37,8 +37,8 @@ devDependencies:
     specifier: ^5.4.4
     version: 5.4.4
   typescript-eslint:
-    specifier: ^7.5.0
-    version: 7.5.0(eslint@9.0.0)(typescript@5.4.4)
+    specifier: ^7.6.0
+    version: 7.6.0(eslint@9.0.0)(typescript@5.4.4)
   vitest:
     specifier: ^1.4.0
     version: 1.4.0(@vitest/ui@1.4.0)
@@ -579,7 +579,7 @@ packages:
       size-limit: 11.1.2
     dependencies:
       esbuild: 0.20.2
-      nanoid: 5.0.6
+      nanoid: 5.0.7
       size-limit: 11.1.2
     dev: true
 
@@ -638,8 +638,8 @@ packages:
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@7.5.0(@typescript-eslint/parser@7.5.0)(eslint@9.0.0)(typescript@5.4.4):
-    resolution: {integrity: sha512-HpqNTH8Du34nLxbKgVMGljZMG0rJd2O9ecvr2QLYp+7512ty1j42KnsFwspPXg1Vh8an9YImf6CokUBltisZFQ==}
+  /@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0)(eslint@9.0.0)(typescript@5.4.4):
+    resolution: {integrity: sha512-gKmTNwZnblUdnTIJu3e9kmeRRzV2j1a/LUO27KNNAnIC5zjy1aSvXSRp4rVNlmAoHlQ7HzX42NbKpcSr4jF80A==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^7.0.0
@@ -650,11 +650,11 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.5.0(eslint@9.0.0)(typescript@5.4.4)
-      '@typescript-eslint/scope-manager': 7.5.0
-      '@typescript-eslint/type-utils': 7.5.0(eslint@9.0.0)(typescript@5.4.4)
-      '@typescript-eslint/utils': 7.5.0(eslint@9.0.0)(typescript@5.4.4)
-      '@typescript-eslint/visitor-keys': 7.5.0
+      '@typescript-eslint/parser': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
+      '@typescript-eslint/scope-manager': 7.6.0
+      '@typescript-eslint/type-utils': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
+      '@typescript-eslint/utils': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
+      '@typescript-eslint/visitor-keys': 7.6.0
       debug: 4.3.4
       eslint: 9.0.0
       graphemer: 1.4.0
@@ -667,8 +667,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@7.5.0(eslint@9.0.0)(typescript@5.4.4):
-    resolution: {integrity: sha512-cj+XGhNujfD2/wzR1tabNsidnYRaFfEkcULdcIyVBYcXjBvBKOes+mpMBP7hMpOyk+gBcfXsrg4NBGAStQyxjQ==}
+  /@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4):
+    resolution: {integrity: sha512-usPMPHcwX3ZoPWnBnhhorc14NJw9J4HpSXQX4urF2TPKG0au0XhJoZyX62fmvdHONUkmyUe74Hzm1//XA+BoYg==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -677,10 +677,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 7.5.0
-      '@typescript-eslint/types': 7.5.0
-      '@typescript-eslint/typescript-estree': 7.5.0(typescript@5.4.4)
-      '@typescript-eslint/visitor-keys': 7.5.0
+      '@typescript-eslint/scope-manager': 7.6.0
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/typescript-estree': 7.6.0(typescript@5.4.4)
+      '@typescript-eslint/visitor-keys': 7.6.0
       debug: 4.3.4
       eslint: 9.0.0
       typescript: 5.4.4
@@ -688,16 +688,16 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@7.5.0:
-    resolution: {integrity: sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==}
+  /@typescript-eslint/scope-manager@7.6.0:
+    resolution: {integrity: sha512-ngttyfExA5PsHSx0rdFgnADMYQi+Zkeiv4/ZxGYUWd0nLs63Ha0ksmp8VMxAIC0wtCFxMos7Lt3PszJssG/E6w==}
     engines: {node: ^18.18.0 || >=20.0.0}
     dependencies:
-      '@typescript-eslint/types': 7.5.0
-      '@typescript-eslint/visitor-keys': 7.5.0
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/visitor-keys': 7.6.0
     dev: true
 
-  /@typescript-eslint/type-utils@7.5.0(eslint@9.0.0)(typescript@5.4.4):
-    resolution: {integrity: sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==}
+  /@typescript-eslint/type-utils@7.6.0(eslint@9.0.0)(typescript@5.4.4):
+    resolution: {integrity: sha512-NxAfqAPNLG6LTmy7uZgpK8KcuiS2NZD/HlThPXQRGwz6u7MDBWRVliEEl1Gj6U7++kVJTpehkhZzCJLMK66Scw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -706,8 +706,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.5.0(typescript@5.4.4)
-      '@typescript-eslint/utils': 7.5.0(eslint@9.0.0)(typescript@5.4.4)
+      '@typescript-eslint/typescript-estree': 7.6.0(typescript@5.4.4)
+      '@typescript-eslint/utils': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
       debug: 4.3.4
       eslint: 9.0.0
       ts-api-utils: 1.3.0(typescript@5.4.4)
@@ -716,13 +716,13 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@7.5.0:
-    resolution: {integrity: sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==}
+  /@typescript-eslint/types@7.6.0:
+    resolution: {integrity: sha512-h02rYQn8J+MureCvHVVzhl69/GAfQGPQZmOMjG1KfCl7o3HtMSlPaPUAPu6lLctXI5ySRGIYk94clD/AUMCUgQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@7.5.0(typescript@5.4.4):
-    resolution: {integrity: sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==}
+  /@typescript-eslint/typescript-estree@7.6.0(typescript@5.4.4):
+    resolution: {integrity: sha512-+7Y/GP9VuYibecrCQWSKgl3GvUM5cILRttpWtnAu8GNL9j11e4tbuGZmZjJ8ejnKYyBRb2ddGQ3rEFCq3QjMJw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       typescript: '*'
@@ -730,12 +730,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 7.5.0
-      '@typescript-eslint/visitor-keys': 7.5.0
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/visitor-keys': 7.6.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      minimatch: 9.0.3
+      minimatch: 9.0.4
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.4.4)
       typescript: 5.4.4
@@ -743,8 +743,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@7.5.0(eslint@9.0.0)(typescript@5.4.4):
-    resolution: {integrity: sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==}
+  /@typescript-eslint/utils@7.6.0(eslint@9.0.0)(typescript@5.4.4):
+    resolution: {integrity: sha512-x54gaSsRRI+Nwz59TXpCsr6harB98qjXYzsRxGqvA5Ue3kQH+FxS7FYU81g/omn22ML2pZJkisy6Q+ElK8pBCA==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -752,9 +752,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 7.5.0
-      '@typescript-eslint/types': 7.5.0
-      '@typescript-eslint/typescript-estree': 7.5.0(typescript@5.4.4)
+      '@typescript-eslint/scope-manager': 7.6.0
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/typescript-estree': 7.6.0(typescript@5.4.4)
       eslint: 9.0.0
       semver: 7.6.0
     transitivePeerDependencies:
@@ -762,11 +762,11 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@7.5.0:
-    resolution: {integrity: sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==}
+  /@typescript-eslint/visitor-keys@7.6.0:
+    resolution: {integrity: sha512-4eLB7t+LlNUmXzfOu1VAIAdkjbu5xNSerURS9X/S5TUKWFRpXRQZbmtPqgKmYx8bj3J0irtQXSiWAOY82v+cgw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     dependencies:
-      '@typescript-eslint/types': 7.5.0
+      '@typescript-eslint/types': 7.6.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -1193,8 +1193,8 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
-  /eslint-plugin-vitest@0.4.2-beta.3(eslint@9.0.0)(typescript@5.4.4)(vitest@1.4.0):
-    resolution: {integrity: sha512-3SrcEvVKEA0k8HkOpWkdU6zMlbt2fPG14LATAYvdvF9v5cuQ2Q2wWi7VcTcpV5QXMQYIyKmfBd2+lYu+OmEr2w==}
+  /eslint-plugin-vitest@0.4.2-beta.5(eslint@9.0.0)(typescript@5.4.4)(vitest@1.4.0):
+    resolution: {integrity: sha512-+KgsqDasq94KUNc0qHw9J5sPmuPdRqwkSSXfSbboYPFasWwdoxixR0ArQt4CTjER2j9tRik4Kd6Ldf4aMFb0JA==}
     engines: {node: ^18.0.0 || >= 20.0.0}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '*'
@@ -1206,7 +1206,7 @@ packages:
       vitest:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 7.5.0(eslint@9.0.0)(typescript@5.4.4)
+      '@typescript-eslint/utils': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
       eslint: 9.0.0
       vitest: 1.4.0(@vitest/ui@1.4.0)
     transitivePeerDependencies:
@@ -1870,8 +1870,8 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
-  /minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+  /minimatch@9.0.4:
+    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
@@ -1910,8 +1910,8 @@ packages:
     hasBin: true
     dev: true
 
-  /nanoid@5.0.6:
-    resolution: {integrity: sha512-rRq0eMHoGZxlvaFOUdK1Ev83Bd1IgzzR+WJ3IbDJ7QOSdAxYjlurSPqFs9s4lJg29RT6nPwizFtJhQS6V5xgiA==}
+  /nanoid@5.0.7:
+    resolution: {integrity: sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
     dev: true
@@ -2502,8 +2502,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typescript-eslint@7.5.0(eslint@9.0.0)(typescript@5.4.4):
-    resolution: {integrity: sha512-eKhF39LRi2xYvvXh3h3S+mCxC01dZTIZBlka25o39i81VeQG+OZyfC4i2GEDspNclMRdXkg9uGhmvWMhjph2XQ==}
+  /typescript-eslint@7.6.0(eslint@9.0.0)(typescript@5.4.4):
+    resolution: {integrity: sha512-LY6vH6F1l5jpGqRtU+uK4+mOecIb4Cd4kaz1hAiJrgnNiHUA8wiw8BkJyYS+MRLM69F1QuSKwtGlQqnGl1Rc6w==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -2512,9 +2512,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.5.0(@typescript-eslint/parser@7.5.0)(eslint@9.0.0)(typescript@5.4.4)
-      '@typescript-eslint/parser': 7.5.0(eslint@9.0.0)(typescript@5.4.4)
-      '@typescript-eslint/utils': 7.5.0(eslint@9.0.0)(typescript@5.4.4)
+      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0)(eslint@9.0.0)(typescript@5.4.4)
+      '@typescript-eslint/parser': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
+      '@typescript-eslint/utils': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
       eslint: 9.0.0
       typescript: 5.4.4
     transitivePeerDependencies:

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -111,10 +111,10 @@ describe('duration', () => {
   const durationInDays = { d: 43 }
 
   test('is a function', () => expect(duration).toBeInstanceOf(Function))
-  test('()', () => expect(() => duration(null)).toThrow())
+  test('(null)', () => expect(() => duration(null)).toThrow())
   test('()', () => expect(duration()).toBe('PT0S'))
   test('empty object {}', () => expect(duration({})).toBe('PT0S'))
-  test('empty object {}', () => expect(duration({}, false)).toBe('PT0S'))
+  test('empty object {} and preserve excess value', () => expect(duration({}, false)).toBe('PT0S'))
 
   test('complete object', () => expect(duration(durationObject)).toBe('P3W5DT10H43M2.61S'))
   test('complete object with too high values', () => expect(duration(durationWithTooHighValues)).toBe('P5W6DT12H55M55.3S'))

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -257,7 +257,7 @@ describe('DateTime class', () => {
   test(".to('month')", () => expect(twoWeeksAfterSummer.to('month')).toBe('2021-07'))
   test('weeks is changed when day changes', () => {
     summer.setDate(summer.getDate() + 14)
-    return expect(summer.getWeek()).toBe(29)
+    expect(summer.getWeek()).toBe(29)
   })
 })
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -111,7 +111,7 @@ describe('duration', () => {
   const durationInDays = { d: 43 }
 
   test('is a function', () => expect(duration).toBeInstanceOf(Function))
-  test('(null)', () => expect(() => duration(null)).toThrow())
+  test('(null)', () => expect(() => duration(null)).toThrow(Error))
   test('()', () => expect(duration()).toBe('PT0S'))
   test('empty object {}', () => expect(duration({})).toBe('PT0S'))
   test('empty object {} and preserve excess value', () => expect(duration({}, false)).toBe('PT0S'))


### PR DESCRIPTION
For now it fails and throws:

```sh
> pnpm exec eslint


Oops! Something went wrong! :(

ESLint: 9.0.0

TypeError: context.getAncestors is not a function
Occurred while linting /Users/m/Code/datetime-attribute/tests/index.test.js:41
Rule: "vitest/expect-expect"
    at CallExpression (file:///Users/m/Code/datetime-attribute/node_modules/.pnpm/eslint-plugin-vitest@0.4.2-beta.3_eslint@9.0.0_typescript@5.4.4_vitest@1.4.0/node_modules/eslint-plugin-vitest/dist/index.mjs:751:39)
    at ruleErrorHandler (/Users/m/Code/datetime-attribute/node_modules/.pnpm/eslint@9.0.0/node_modules/eslint/lib/linter/linter.js:1145:48)
    at /Users/m/Code/datetime-attribute/node_modules/.pnpm/eslint@9.0.0/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/m/Code/datetime-attribute/node_modules/.pnpm/eslint@9.0.0/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/Users/m/Code/datetime-attribute/node_modules/.pnpm/eslint@9.0.0/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (/Users/m/Code/datetime-attribute/node_modules/.pnpm/eslint@9.0.0/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
    at NodeEventGenerator.enterNode (/Users/m/Code/datetime-attribute/node_modules/.pnpm/eslint@9.0.0/node_modules/eslint/lib/linter/node-event-generator.js:340:14)
    at runRules (/Users/m/Code/datetime-attribute/node_modules/.pnpm/eslint@9.0.0/node_modules/eslint/lib/linter/linter.js:1184:40)
    at Linter._verifyWithFlatConfigArrayAndWithoutProcessors (/Users/m/Code/datetime-attribute/node_modules/.pnpm/eslint@9.0.0/node_modules/eslint/lib/linter/linter.js:1910:31)
 ELIFECYCLE  Command failed with exit code 2.
```