### PR TITLE
Add some tests to `tzOffset`

### DIFF
--- a/src/timezone.test.js
+++ b/src/timezone.test.js
@@ -21,48 +21,88 @@ describe('tzOffset', () => {
 
   describe('in boundaries', () => {
 
-    test('tzOffset(-8)      is -08:00', () => {
+    test('tzOffset(-23, -59)  is -23:59', () => {
+      expect(tzOffset(-23, -59)).toBe('-23:59')
+    })
+
+    test('tzOffset(-9, -30)   is -09:30', () => {
+      expect(tzOffset(-9, -30)).toBe('-09:30')
+    })
+
+    test('tzOffset(-9, 30)    is -08:30', () => {
+      expect(tzOffset(-9, 30)).toBe('-08:30')
+    })
+
+    test('tzOffset(-8)        is -08:00', () => {
       expect(tzOffset(-8)).toBe('-08:00')
     })
 
-    test('tzOffset(-4.5)    is -04:30', () => {
+    test('tzOffset(-4.5)      is -04:30', () => {
       expect(tzOffset(-4.5)).toBe('-04:30')
     })
 
-    test('tzOffset(0, -30)  is -00:30', () => {
+    test('tzOffset(0, -30)    is -00:30', () => {
       expect(tzOffset(0, -30)).toBe('-00:30')
     })
 
-    test('tzOffset(0)       is Z', () => {
+    test('tzOffset(0)         is Z', () => {
       expect(tzOffset(0)).toBe('Z')
     })
 
-    test('tzOffset(0, 30)   is +00:30', () => {
+    test('tzOffset(0, 30)     is +00:30', () => {
       expect(tzOffset(0, 30)).toBe('+00:30')
     })
 
-    test('tzOffset(1)       is +01:00', () => {
+    test('tzOffset(1)         is +01:00', () => {
       expect(tzOffset(1)).toBe('+01:00')
     })
 
-    test('tzOffset(2, -200) is -01:20', () => {
+    test('tzOffset(2, -200)   is -01:20', () => {
       expect(tzOffset(2, -200)).toBe('-01:20')
     })
 
-    test('tzOffset(4, 30)   is +04:30', () => {
+    test('tzOffset(4, 30)     is +04:30', () => {
       expect(tzOffset(4, 30)).toBe('+04:30')
     })
 
-    test('tzOffset(12, 45)  is +12:45', () => {
+    test('tzOffset(12, 45)    is +12:45', () => {
       expect(tzOffset(12, 45)).toBe('+12:45')
     })
 
-    test('tzOffset(12.75)   is +12:45', () => {
+    test('tzOffset(12.75)     is +12:45', () => {
       expect(tzOffset(12.75)).toBe('+12:45')
+    })
+
+    test('tzOffset(23, 59)    is +23:59', () => {
+      expect(tzOffset(23, 59)).toBe('+23:59')
     })
   })
 
   describe('out of boundaries', () => {
+
+    test('tzOffset(-24)            is Z', () => {
+      expect(tzOffset(-24)).toBe('Z')
+    })
+
+    test('tzOffset(24)             is Z', () => {
+      expect(tzOffset(24)).toBe('Z')
+    })
+
+    test('tzOffset(-24, 0, true)   is Z', () => {
+      expect(tzOffset(-24, 0, true)).toBe('Z')
+    })
+
+    test('tzOffset(24, 0, true)    is Z', () => {
+      expect(tzOffset(24, 0, true)).toBe('Z')
+    })
+
+    test('tzOffset(-24, -1)        is -00:01', () => {
+      expect(tzOffset(-24, -1)).toBe('-00:01')
+    })
+
+    test('tzOffset(24, 1)          is 00:01', () => {
+      expect(tzOffset(24, 1)).toBe('+00:01')
+    })
 
     test('tzOffset(-35)            is -11:00', () => {
       expect(tzOffset(-35)).toBe('-11:00')


### PR DESCRIPTION
They will help maintain consistency in the future, especially when using the `Temporal` API.

The organization of the tests is a bit rough but can be improve later.